### PR TITLE
Command fix

### DIFF
--- a/src/LionBundle/Commands/Lion/DB/CrudCommand.php
+++ b/src/LionBundle/Commands/Lion/DB/CrudCommand.php
@@ -189,7 +189,7 @@ class CrudCommand extends MenuCommand
             ->find('new:test')
             ->run(
                 new ArrayInput([
-                    'test' => "app/Http/Controllers/{$connectionPascal}/MySQL/{$entityPascal}ControllerTest"
+                    'test' => "App/Http/Controllers/{$connectionPascal}/MySQL/{$entityPascal}ControllerTest"
                 ]),
                 $output
             );
@@ -198,7 +198,7 @@ class CrudCommand extends MenuCommand
             ->getApplication()
             ->find('new:test')
             ->run(
-                new ArrayInput(['test' => "app/Models/{$connectionPascal}/MySQL/{$entityPascal}ModelTest"]),
+                new ArrayInput(['test' => "App/Models/{$connectionPascal}/MySQL/{$entityPascal}ModelTest"]),
                 $output
             );
 
@@ -383,14 +383,14 @@ class CrudCommand extends MenuCommand
     ): void {
         $this
             ->getApplication()
-            ->find('db:mysql:capsule')
+            ->find('db:capsule')
             ->run(new ArrayInput(['entity' => $entity]), $output);
 
         $this
             ->getApplication()
             ->find('new:test')
             ->run(
-                new ArrayInput(['test' => "database/Class/{$selectedConnection}/MySQL/{$entityPascal}Test",]),
+                new ArrayInput(['test' => "Database/Class/{$selectedConnection}/MySQL/{$entityPascal}Test",]),
                 $output
             );
     }
@@ -433,7 +433,7 @@ class CrudCommand extends MenuCommand
         foreach ($columns as $key => $column) {
             if ('PRI' === $column->Key) {
                 $methods['update'] = [
-                    ...$this->arr->of($methods['update'])->where(fn($value, $key) => $key != 0)->get(),
+                    ...$this->arr->of($methods['update'])->where(fn ($value, $key) => $key != 0)->get(),
                     reset($methods['update'])
                 ];
             }

--- a/src/LionBundle/Commands/Lion/DB/DBCapsuleCommand.php
+++ b/src/LionBundle/Commands/Lion/DB/DBCapsuleCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Lion\Bundle\Commands\Lion\DB\MySQL;
+namespace Lion\Bundle\Commands\Lion\DB;
 
 use Lion\Bundle\Helpers\Commands\ClassFactory;
 use Lion\Bundle\Helpers\Commands\Selection\MenuCommand;
@@ -45,7 +45,7 @@ class DBCapsuleCommand extends MenuCommand
     protected function configure(): void
     {
         $this
-            ->setName('db:mysql:capsule')
+            ->setName('db:capsule')
             ->setDescription('Command required for the creation of new Capsules')
             ->addArgument('entity', InputArgument::REQUIRED, 'Entity name', null);
     }

--- a/src/LionBundle/Commands/Lion/DB/DBSeedCommand.php
+++ b/src/LionBundle/Commands/Lion/DB/DBSeedCommand.php
@@ -98,7 +98,7 @@ class DBSeedCommand extends Command
 
         $end = (int) $input->getOption('run');
 
-        /** @var array<SeedInterface> $files */
+        /** @var array<int, SeedInterface> $files */
         $files = [];
 
         foreach ($this->container->getFiles('./database/Seed/') as $seed) {

--- a/src/LionBundle/Commands/Lion/New/SeedCommand.php
+++ b/src/LionBundle/Commands/Lion/New/SeedCommand.php
@@ -131,7 +131,10 @@ class SeedCommand extends Command
                      */
                     public function run(): object
                     {
-                        return success('run seed');
+                        return (object) [
+                            'status' => 'success',
+                            'message' => 'run seed',
+                        ];
                     }
                 }
 

--- a/src/LionBundle/Helpers/Commands/Migrations/MigrationFactory.php
+++ b/src/LionBundle/Helpers/Commands/Migrations/MigrationFactory.php
@@ -39,22 +39,40 @@ class MigrationFactory
      */
     public function getTableBody(): string
     {
-        return $this->str->of("<?php")->ln()->ln()
-            ->concat('declare(strict_types=1);')->ln()->ln()
-            ->concat("use Lion\Bundle\Interface\MigrationUpInterface;")->ln()
-            ->concat("use Lion\Database\Drivers\Schema\MySQL as DB;")->ln()->ln()
-            ->concat("return new class implements MigrationUpInterface\n{")->ln()
-            ->lt()->concat('const INDEX = null;')->ln()->ln()
-            ->lt()->concat("/**\n\t * {@inheritdoc}\n\t */")->ln()
-            ->lt()->concat("public function up(): object\n\t{")->ln()
-            ->lt()->lt()->concat("return DB::connection(env('--CONNECTION--', 'lion_database'))")->ln()
-            ->lt()->lt()->lt()->concat("->createTable('example', function() {")->ln()
-            ->lt()->lt()->lt()->lt()->concat("DB::int('id')->notNull()->autoIncrement()->primaryKey();")->ln()
-            ->lt()->lt()->lt()->concat('})')->ln()
-            ->lt()->lt()->lt()->concat("->execute();")->ln()
-            ->lt()->concat("}")->ln()
-            ->concat("};")->ln()
-            ->get();
+        return <<<PHP
+        <?php
+
+        declare(strict_types=1);
+
+        use Lion\Bundle\Interface\Migrations\TableInterface;
+        use Lion\Database\Drivers\Schema\MySQL as Schema;
+
+        /**
+         * Description
+         */
+        return new class implements TableInterface
+        {
+            /**
+             * [Index number for seed execution priority]
+             *
+             * @const INDEX
+             */
+            const INDEX = null;
+
+            /**
+             * {@inheritdoc}
+             */
+            public function up(): object
+            {
+                return Schema::connection(env('DB_NAME', 'lion_database'))
+                    ->createTable('example', function (): void {
+                        Schema::int('id')->notNull()->autoIncrement()->primaryKey();
+                    })
+                    ->execute();
+            }
+        };
+
+        PHP;
     }
 
     /**
@@ -64,22 +82,36 @@ class MigrationFactory
      */
     public function getViewBody(): string
     {
-        return $this->str->of("<?php")->ln()->ln()
-            ->concat('declare(strict_types=1);')->ln()->ln()
-            ->concat("use Lion\Bundle\Interface\MigrationUpInterface;")->ln()
-            ->concat("use Lion\Database\Drivers\MySQL;")->ln()
-            ->concat("use Lion\Database\Drivers\Schema\MySQL as Schema;")->ln()->ln()
-            ->concat("return new class implements MigrationUpInterface\n{")->ln()
-            ->lt()->concat("/**\n\t * {@inheritdoc}\n\t * */")->ln()
-            ->lt()->concat("public function up(): object\n\t{")->ln()
-            ->lt()->lt()->concat("return Schema::connection(env('--CONNECTION--', 'lion_database'))")->ln()
-            ->lt()->lt()->lt()->concat("->createView('read_example', " . 'function(MySQL $db) {')->ln()
-            ->lt()->lt()->lt()->lt()->concat('$db->table' . "('table')->select();")->ln()
-            ->lt()->lt()->lt()->concat("})")->ln()
-            ->lt()->lt()->lt()->concat("->execute();")->ln()
-            ->lt()->concat("}")->ln()
-            ->concat("};")
-            ->get();
+        return <<<PHP
+        <?php
+
+        declare(strict_types=1);
+
+        use Lion\Bundle\Interface\Migrations\ViewInterface;
+        use Lion\Database\Drivers\MySQL;
+        use Lion\Database\Drivers\Schema\MySQL as Schema;
+
+        /**
+         * Description
+         */
+        return new class implements ViewInterface
+        {
+            /**
+             * {@inheritdoc}
+             * */
+            public function up(): object
+            {
+                return Schema::connection(env('DB_NAME', 'lion_database'))
+                    ->createView('read_example', function (MySQL \$db): void {
+                        \$db
+                            ->table('table')
+                            ->select();
+                    })
+                    ->execute();
+            }
+        };
+
+        PHP;
     }
 
     /**
@@ -89,23 +121,37 @@ class MigrationFactory
      */
     public function getStoreProcedureBody(): string
     {
-        return $this->str->of("<?php")->ln()->ln()
-            ->concat('declare(strict_types=1);')->ln()->ln()
-            ->concat('use Lion\Bundle\Interface\MigrationUpInterface;')->ln()
-            ->concat('use Lion\Database\Drivers\MySQL;')->ln()
-            ->concat('use Lion\Database\Drivers\Schema\MySQL as Schema;')->ln()->ln()
-            ->concat("return new class implements MigrationUpInterface\n{")->ln()
-            ->lt()->concat("/**\n\t * {@inheritdoc}\n\t * */")->ln()
-            ->lt()->concat("public function up(): object\n\t{")->ln()
-            ->lt()->lt()->concat("return Schema::connection(env('--CONNECTION--', 'lion_database'))")->ln()
-            ->lt()->lt()->lt()->concat("->createStoreProcedure('example', function() {")->ln()
-            ->lt()->lt()->lt()->lt()->concat("Schema::in()->varchar('name', 25);")->ln()
-            ->lt()->lt()->lt()->concat('}, function(MySQL $db) {')->ln()
-            ->lt()->lt()->lt()->lt()->concat('$db->table(' . "''" . ')->insert([' . "'name' => ''" . ']);')->ln()
-            ->lt()->lt()->lt()->concat('})')->ln()
-            ->lt()->lt()->lt()->concat("->execute();")->ln()
-            ->lt()->concat("}")->ln()
-            ->concat("};")
-            ->get();
+        return <<<PHP
+        <?php
+
+        declare(strict_types=1);
+
+        use Lion\Bundle\Interface\Migrations\StoreProcedureInterface;
+        use Lion\Database\Drivers\MySQL;
+        use Lion\Database\Drivers\Schema\MySQL as Schema;
+
+        /**
+         * Description
+         */
+        return new class implements StoreProcedureInterface
+        {
+            /**
+             * {@inheritdoc}
+             * */
+            public function up(): object
+            {
+                return Schema::connection(env('DB_NAME', 'lion_database'))
+                    ->createStoreProcedure('example', function (): void {
+                        Schema::in()->varchar('name', 25);
+                    }, function (MySQL \$db): void {
+                        \$db
+                            ->table('')
+                            ->insert(['name' => '']);
+                    })
+                    ->execute();
+            }
+        };
+
+        PHP;
     }
 }

--- a/src/LionBundle/Interface/Migrations/StoreProcedureInterface.php
+++ b/src/LionBundle/Interface/Migrations/StoreProcedureInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lion\Bundle\Interface\Migrations;
+
+use Lion\Bundle\Interface\MigrationUpInterface;
+
+/**
+ * Defines a stored procedure type migration
+ */
+interface StoreProcedureInterface extends MigrationUpInterface
+{
+}

--- a/src/LionBundle/Interface/Migrations/TableInterface.php
+++ b/src/LionBundle/Interface/Migrations/TableInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lion\Bundle\Interface\Migrations;
+
+use Lion\Bundle\Interface\MigrationUpInterface;
+
+/**
+ * Defines a table type migration
+ */
+interface TableInterface extends MigrationUpInterface
+{
+}

--- a/src/LionBundle/Interface/Migrations/ViewInterface.php
+++ b/src/LionBundle/Interface/Migrations/ViewInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lion\Bundle\Interface\Migrations;
+
+use Lion\Bundle\Interface\MigrationUpInterface;
+
+/**
+ * Defines a view type migration
+ */
+interface ViewInterface extends MigrationUpInterface
+{
+}

--- a/tests/Commands/Lion/DB/CrudCommandTest.php
+++ b/tests/Commands/Lion/DB/CrudCommandTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Commands\Lion\DB;
 
 use Lion\Bundle\Commands\Lion\DB\CrudCommand;
-use Lion\Bundle\Commands\Lion\DB\MySQL\DBCapsuleCommand;
+use Lion\Bundle\Commands\Lion\DB\DBCapsuleCommand;
 use Lion\Bundle\Commands\Lion\DB\RulesDBCommand;
 use Lion\Bundle\Commands\Lion\New\CapsuleCommand;
 use Lion\Bundle\Commands\Lion\New\ControllerCommand;

--- a/tests/Commands/Lion/DB/DBCapsuleCommandTest.php
+++ b/tests/Commands/Lion/DB/DBCapsuleCommandTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Tests\Commands\Lion\DB\MySQL;
+namespace Tests\Commands\Lion\DB;
 
-use Lion\Bundle\Commands\Lion\DB\MySQL\DBCapsuleCommand;
+use Lion\Bundle\Commands\Lion\DB\DBCapsuleCommand;
 use Lion\Bundle\Commands\Lion\New\CapsuleCommand;
 use Lion\Command\Command;
 use Lion\Command\Kernel;
@@ -30,6 +30,7 @@ class DBCapsuleCommandTest extends Test
     protected function setUp(): void
     {
         $this->runDatabaseConnections();
+
         $this->createDirectory(self::URL_PATH);
 
         Schema::createTable(self::ENTITY, function () {
@@ -38,14 +39,18 @@ class DBCapsuleCommandTest extends Test
         })->execute();
 
         $application = (new Kernel())->getApplication();
+
         $application->add((new Container())->injectDependencies(new CapsuleCommand()));
+
         $application->add((new Container())->injectDependencies(new DBCapsuleCommand()));
-        $this->commandTester = new CommandTester($application->find('db:mysql:capsule'));
+
+        $this->commandTester = new CommandTester($application->find('db:capsule'));
     }
 
     protected function tearDown(): void
     {
         Schema::dropTable(self::ENTITY)->execute();
+
         $this->rmdirRecursively('./database/');
     }
 

--- a/tests/Commands/Lion/Migrations/FreshMigrationsCommandTest.php
+++ b/tests/Commands/Lion/Migrations/FreshMigrationsCommandTest.php
@@ -34,6 +34,7 @@ class FreshMigrationsCommandTest extends Test
     protected function setUp(): void
     {
         $kernel = new Kernel();
+
         $container = new Container();
 
         $kernel->commandsOnObjects([
@@ -44,7 +45,9 @@ class FreshMigrationsCommandTest extends Test
         ]);
 
         $this->commandTesterNew = new CommandTester($kernel->getApplication()->find('new:migration'));
+
         $this->commandTesterSeed = new CommandTester($kernel->getApplication()->find('new:seed'));
+
         $this->commandTesterFresh = new CommandTester($kernel->getApplication()->find('migrate:fresh'));
 
         $this->createDirectory('./database/Migrations/');

--- a/tests/Helpers/Commands/Migrations/MigrationFactoryTest.php
+++ b/tests/Helpers/Commands/Migrations/MigrationFactoryTest.php
@@ -6,101 +6,129 @@ namespace Tests\Helpers\Commands\Migrations;
 
 use Lion\Bundle\Helpers\Commands\Migrations\MigrationFactory;
 use Lion\Dependency\Injection\Container;
-use Lion\Helpers\Str;
 use Lion\Test\Test;
 
 class MigrationFactoryTest extends Test
 {
     private MigrationFactory $migrationFactory;
-    private Str $str;
 
     protected function setUp(): void
     {
-        $this->migrationFactory = (new Container())->injectDependencies(new MigrationFactory());
-
-        $this->str = new Str();
+        $this->migrationFactory = (new Container())
+            ->injectDependencies(new MigrationFactory());
     }
 
     public function testGetTableBody(): void
     {
-        $tableBody = $this->migrationFactory->getTableBody();
+        $tableBody = <<<PHP
+        <?php
 
-        $this->assertIsString($tableBody);
+        declare(strict_types=1);
 
-        $this->assertSame(
-            $this->str->of("<?php")->ln()->ln()
-                ->concat('declare(strict_types=1);')->ln()->ln()
-                ->concat("use Lion\Bundle\Interface\MigrationUpInterface;")->ln()
-                ->concat("use Lion\Database\Drivers\Schema\MySQL as DB;")->ln()->ln()
-                ->concat("return new class implements MigrationUpInterface\n{")->ln()
-                ->lt()->concat('const INDEX = null;')->ln()->ln()
-                ->lt()->concat("/**\n\t * {@inheritdoc}\n\t */")->ln()
-                ->lt()->concat("public function up(): object\n\t{")->ln()
-                ->lt()->lt()->concat("return DB::connection(env('--CONNECTION--', 'lion_database'))")->ln()
-                ->lt()->lt()->lt()->concat("->createTable('example', function() {")->ln()
-                ->lt()->lt()->lt()->lt()->concat("DB::int('id')->notNull()->autoIncrement()->primaryKey();")->ln()
-                ->lt()->lt()->lt()->concat('})')->ln()
-                ->lt()->lt()->lt()->concat("->execute();")->ln()
-                ->lt()->concat("}")->ln()
-                ->concat("};")->ln()
-                ->get(),
-            $tableBody
-        );
+        use Lion\Bundle\Interface\Migrations\TableInterface;
+        use Lion\Database\Drivers\Schema\MySQL as Schema;
+
+        /**
+         * Description
+         */
+        return new class implements TableInterface
+        {
+            /**
+             * [Index number for seed execution priority]
+             *
+             * @const INDEX
+             */
+            const INDEX = null;
+
+            /**
+             * {@inheritdoc}
+             */
+            public function up(): object
+            {
+                return Schema::connection(env('DB_NAME', 'lion_database'))
+                    ->createTable('example', function (): void {
+                        Schema::int('id')->notNull()->autoIncrement()->primaryKey();
+                    })
+                    ->execute();
+            }
+        };
+
+        PHP;
+
+        $this->assertSame($tableBody, $this->migrationFactory->getTableBody());
     }
 
     public function testGetViewBody(): void
     {
-        $viewBody = $this->migrationFactory->getViewBody();
+        $viewBody = <<<PHP
+        <?php
 
-        $this->assertIsString($viewBody);
+        declare(strict_types=1);
 
-        $this->assertSame(
-            $this->str->of("<?php")->ln()->ln()
-                ->concat('declare(strict_types=1);')->ln()->ln()
-                ->concat("use Lion\Bundle\Interface\MigrationUpInterface;")->ln()
-                ->concat("use Lion\Database\Drivers\MySQL;")->ln()
-                ->concat("use Lion\Database\Drivers\Schema\MySQL as Schema;")->ln()->ln()
-                ->concat("return new class implements MigrationUpInterface\n{")->ln()
-                ->lt()->concat("/**\n\t * {@inheritdoc}\n\t * */")->ln()
-                ->lt()->concat("public function up(): object\n\t{")->ln()
-                ->lt()->lt()->concat("return Schema::connection(env('--CONNECTION--', 'lion_database'))")->ln()
-                ->lt()->lt()->lt()->concat("->createView('read_example', " . 'function(MySQL $db) {')->ln()
-                ->lt()->lt()->lt()->lt()->concat('$db->table' . "('table')->select();")->ln()
-                ->lt()->lt()->lt()->concat("})")->ln()
-                ->lt()->lt()->lt()->concat("->execute();")->ln()
-                ->lt()->concat("}")->ln()
-                ->concat("};")
-                ->get(),
-            $viewBody
-        );
+        use Lion\Bundle\Interface\Migrations\ViewInterface;
+        use Lion\Database\Drivers\MySQL;
+        use Lion\Database\Drivers\Schema\MySQL as Schema;
+
+        /**
+         * Description
+         */
+        return new class implements ViewInterface
+        {
+            /**
+             * {@inheritdoc}
+             * */
+            public function up(): object
+            {
+                return Schema::connection(env('DB_NAME', 'lion_database'))
+                    ->createView('read_example', function (MySQL \$db): void {
+                        \$db
+                            ->table('table')
+                            ->select();
+                    })
+                    ->execute();
+            }
+        };
+
+        PHP;
+
+        $this->assertSame($viewBody, $this->migrationFactory->getViewBody());
     }
 
     public function testGetStoreProcedureBody(): void
     {
-        $storeProcedureBody = $this->migrationFactory->getStoreProcedureBody();
+        $storeProcedureBody = <<<PHP
+        <?php
 
-        $this->assertIsString($storeProcedureBody);
+        declare(strict_types=1);
 
-        $this->assertSame(
-            $this->str->of("<?php")->ln()->ln()
-                ->concat('declare(strict_types=1);')->ln()->ln()
-                ->concat('use Lion\Bundle\Interface\MigrationUpInterface;')->ln()
-                ->concat('use Lion\Database\Drivers\MySQL;')->ln()
-                ->concat('use Lion\Database\Drivers\Schema\MySQL as Schema;')->ln()->ln()
-                ->concat("return new class implements MigrationUpInterface\n{")->ln()
-                ->lt()->concat("/**\n\t * {@inheritdoc}\n\t * */")->ln()
-                ->lt()->concat("public function up(): object\n\t{")->ln()
-                ->lt()->lt()->concat("return Schema::connection(env('--CONNECTION--', 'lion_database'))")->ln()
-                ->lt()->lt()->lt()->concat("->createStoreProcedure('example', function() {")->ln()
-                ->lt()->lt()->lt()->lt()->concat("Schema::in()->varchar('name', 25);")->ln()
-                ->lt()->lt()->lt()->concat('}, function(MySQL $db) {')->ln()
-                ->lt()->lt()->lt()->lt()->concat('$db->table(' . "''" . ')->insert([' . "'name' => ''" . ']);')->ln()
-                ->lt()->lt()->lt()->concat('})')->ln()
-                ->lt()->lt()->lt()->concat("->execute();")->ln()
-                ->lt()->concat("}")->ln()
-                ->concat("};")
-                ->get(),
-            $storeProcedureBody
-        );
+        use Lion\Bundle\Interface\Migrations\StoreProcedureInterface;
+        use Lion\Database\Drivers\MySQL;
+        use Lion\Database\Drivers\Schema\MySQL as Schema;
+
+        /**
+         * Description
+         */
+        return new class implements StoreProcedureInterface
+        {
+            /**
+             * {@inheritdoc}
+             * */
+            public function up(): object
+            {
+                return Schema::connection(env('DB_NAME', 'lion_database'))
+                    ->createStoreProcedure('example', function (): void {
+                        Schema::in()->varchar('name', 25);
+                    }, function (MySQL \$db): void {
+                        \$db
+                            ->table('')
+                            ->insert(['name' => '']);
+                    })
+                    ->execute();
+            }
+        };
+
+        PHP;
+
+        $this->assertSame($storeProcedureBody, $this->migrationFactory->getStoreProcedureBody());
     }
 }


### PR DESCRIPTION
### Added
- Interfaces have been added for different types of migrations.

### Refactoring
- Body of migration types has been modified.
- Command has been renamed db:mysql:capsule to db:capsule.

### Fixed
- Migration execution order has been corrected.
- Fixed seed body.