### PR TITLE
Handling tables modified by databases in migrations

### DIFF
--- a/.env.actions
+++ b/.env.actions
@@ -32,6 +32,9 @@ DB_NAME_TEST_POSTGRESQL="lion_database_postgres"
 DB_USER_TEST_POSTGRESQL="root"
 DB_PASSWORD_TEST_POSTGRESQL="lion"
 ################################################################################
+DB_TYPE_TEST_SQLITE="sqlite"
+DB_NAME_TEST_SQLITE="lion_database.sqlite"
+################################################################################
 ################# REDIS -------------------------------------- #################
 ################################################################################
 REDIS_SCHEME="tcp"

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ DB_NAME_TEST_POSTGRESQL="lion_database_postgres"
 DB_USER_TEST_POSTGRESQL="root"
 DB_PASSWORD_TEST_POSTGRESQL="lion"
 ################################################################################
+DB_TYPE_TEST_SQLITE="sqlite"
+DB_NAME_TEST_SQLITE="lion_database.sqlite"
+################################################################################
 ################# REDIS -------------------------------------- #################
 ################################################################################
 REDIS_SCHEME="tcp"

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "fakerphp/faker": "^1.23",
         "guzzlehttp/guzzle": "^7.9",
         "lion/command": "^5.1",
-        "lion/database": "^11.8",
+        "lion/database": "^11.9",
         "lion/dependency-injection": "^4.2",
         "lion/exceptions": "^2.0",
         "lion/files": "^8.1",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "fakerphp/faker": "^1.23",
         "guzzlehttp/guzzle": "^7.9",
         "lion/command": "^5.1",
-        "lion/database": "^11.9",
+        "lion/database": "^11.10",
         "lion/dependency-injection": "^4.2",
         "lion/exceptions": "^2.0",
         "lion/files": "^8.1",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "fakerphp/faker": "^1.23",
         "guzzlehttp/guzzle": "^7.9",
         "lion/command": "^5.1",
-        "lion/database": "^11.7",
+        "lion/database": "^11.8",
         "lion/dependency-injection": "^4.2",
         "lion/exceptions": "^2.0",
         "lion/files": "^8.1",

--- a/lion
+++ b/lion
@@ -67,6 +67,10 @@ Driver::run([
             'user' => env('DB_USER_TEST_POSTGRESQL'),
             'password' => env('DB_PASSWORD_TEST_POSTGRESQL'),
         ],
+        'lion_database_sqlite' => [
+            'type' => env('DB_TYPE_TEST_SQLITE'),
+            'dbname' => __DIR__ . '/' . env('DB_NAME_TEST_SQLITE'),
+        ],
     ],
 ]);
 

--- a/lion
+++ b/lion
@@ -41,9 +41,9 @@ if (isSuccess((new Store())->exist(__DIR__ . '/.env'))) {
  * */
 
 Driver::run([
-    'default' => env('DB_NAME'),
+    'default' => env('DB_DEFAULT'),
     'connections' => [
-        env('DB_NAME') => [
+        env('DB_DEFAULT') => [
             'type' => env('DB_TYPE'),
             'host' => env('DB_HOST'),
             'port' => env('DB_PORT'),

--- a/npm
+++ b/npm
@@ -41,25 +41,33 @@ if (isSuccess((new Store())->exist(__DIR__ . '/.env'))) {
  * */
 
 Driver::run([
-    'default' => $_ENV['DB_NAME'],
+    'default' => env('DB_DEFAULT'),
     'connections' => [
-        $_ENV['DB_NAME'] => [
-            'type' => $_ENV['DB_TYPE'],
-            'host' => $_ENV['DB_HOST'],
-            'port' => $_ENV['DB_PORT'],
-            'dbname' => $_ENV['DB_NAME'],
-            'user' => $_ENV['DB_USER'],
-            'password' => $_ENV['DB_PASSWORD']
+        env('DB_DEFAULT') => [
+            'type' => env('DB_TYPE'),
+            'host' => env('DB_HOST'),
+            'port' => env('DB_PORT'),
+            'dbname' => env('DB_NAME'),
+            'user' => env('DB_USER'),
+            'password' => env('DB_PASSWORD'),
         ],
-        $_ENV['DB_NAME_TEST'] => [
-            'type' => $_ENV['DB_TYPE_TEST'],
-            'host' => $_ENV['DB_HOST_TEST'],
-            'port' => $_ENV['DB_PORT_TEST'],
-            'dbname' => $_ENV['DB_NAME'],
-            'user' => $_ENV['DB_USER_TEST'],
-            'password' => $_ENV['DB_PASSWORD_TEST']
-        ]
-    ]
+        env('DB_NAME_TEST') => [
+            'type' => env('DB_TYPE_TEST'),
+            'host' => env('DB_HOST_TEST'),
+            'port' => env('DB_PORT_TEST'),
+            'dbname' => env('DB_NAME'),
+            'user' => env('DB_USER_TEST'),
+            'password' => env('DB_PASSWORD_TEST'),
+        ],
+        env('DB_NAME_TEST_POSTGRESQL') => [
+            'type' => env('DB_TYPE_TEST_POSTGRESQL'),
+            'host' => env('DB_HOST_TEST_POSTGRESQL'),
+            'port' => env('DB_PORT_TEST_POSTGRESQL'),
+            'dbname' => env('DB_NAME'),
+            'user' => env('DB_USER_TEST_POSTGRESQL'),
+            'password' => env('DB_PASSWORD_TEST_POSTGRESQL'),
+        ],
+    ],
 ]);
 
 /**

--- a/npm
+++ b/npm
@@ -67,6 +67,10 @@ Driver::run([
             'user' => env('DB_USER_TEST_POSTGRESQL'),
             'password' => env('DB_PASSWORD_TEST_POSTGRESQL'),
         ],
+        'lion_database_sqlite' => [
+            'type' => env('DB_TYPE_TEST_SQLITE'),
+            'dbname' => __DIR__ . '/' . env('DB_NAME_TEST_SQLITE'),
+        ],
     ],
 ]);
 

--- a/src/LionBundle/Commands/Lion/DB/ShowDatabasesCommand.php
+++ b/src/LionBundle/Commands/Lion/DB/ShowDatabasesCommand.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Lion\Bundle\Commands\Lion\DB;
 
-use DI\Attribute\Inject;
 use Lion\Command\Command;
-use Lion\Helpers\Arr;
-use Lion\Database\Drivers\MySQL as DB;
+use Lion\Database\Connection;
 use LogicException;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,21 +18,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ShowDatabasesCommand extends Command
 {
-    /**
-     * [Modify and build arrays with different indexes or values]
-     *
-     * @var Arr $arr
-     */
-    private Arr $arr;
-
-    #[Inject]
-    public function setArr(Arr $arr): ShowDatabasesCommand
-    {
-        $this->arr = $arr;
-
-        return $this;
-    }
-
     /**
      * Configures the current command
      *
@@ -66,9 +49,9 @@ class ShowDatabasesCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $connections = DB::getConnections();
+        $connections = Connection::getConnections();
 
-        $size = $this->arr->of($connections)->length();
+        $size = count($connections);
 
         $listConnections = [];
 
@@ -76,10 +59,14 @@ class ShowDatabasesCommand extends Command
             $listConnections[] = [
                 'connectionName' => $this->infoOutput($connectionName),
                 'type' => "<fg=#FFB63E>{$connection['type']}</>",
-                'host' => $connection['host'],
-                'port' => $connection['port'],
-                'dbname' => $connection['dbname'],
-                'user' => $connection['user']
+                /** @phpstan-ignore-next-line */
+                'host' => $connection['host'] ?? '',
+                /** @phpstan-ignore-next-line */
+                'port' => $connection['port'] ?? '',
+                /** @phpstan-ignore-next-line */
+                'dbname' => $connection['dbname'] ?? '',
+                /** @phpstan-ignore-next-line */
+                'user' => $connection['user'] ?? '',
             ];
         }
 

--- a/src/LionBundle/Commands/Lion/Migrations/FreshMigrationsCommand.php
+++ b/src/LionBundle/Commands/Lion/Migrations/FreshMigrationsCommand.php
@@ -11,7 +11,6 @@ use Lion\Bundle\Interface\Migrations\StoredProcedureInterface;
 use Lion\Bundle\Interface\Migrations\TableInterface;
 use Lion\Bundle\Interface\Migrations\ViewInterface;
 use Lion\Bundle\Interface\MigrationUpInterface;
-use Lion\Command\Command;
 use Lion\Database\Connection;
 use Lion\Database\Driver;
 use Lion\Database\Drivers\PostgreSQL;

--- a/src/LionBundle/Commands/Lion/Migrations/FreshMigrationsCommand.php
+++ b/src/LionBundle/Commands/Lion/Migrations/FreshMigrationsCommand.php
@@ -7,7 +7,7 @@ namespace Lion\Bundle\Commands\Lion\Migrations;
 use DI\Attribute\Inject;
 use Lion\Bundle\Helpers\Commands\Migrations\Migrations;
 use Lion\Bundle\Helpers\Commands\Selection\MenuCommand;
-use Lion\Bundle\Interface\Migrations\StoreProcedureInterface;
+use Lion\Bundle\Interface\Migrations\StoredProcedureInterface;
 use Lion\Bundle\Interface\Migrations\TableInterface;
 use Lion\Bundle\Interface\Migrations\ViewInterface;
 use Lion\Bundle\Interface\MigrationUpInterface;
@@ -120,7 +120,7 @@ class FreshMigrationsCommand extends MenuCommand
         $this->migrations->executeMigrations($this, $output, $migrations[ViewInterface::class]);
 
         /** @phpstan-ignore-next-line */
-        $this->migrations->executeMigrations($this, $output, $migrations[StoreProcedureInterface::class]);
+        $this->migrations->executeMigrations($this, $output, $migrations[StoredProcedureInterface::class]);
 
         $output->writeln($this->infoOutput("\n\t>> Migrations executed successfully"));
 

--- a/src/LionBundle/Commands/Lion/New/MigrationCommand.php
+++ b/src/LionBundle/Commands/Lion/New/MigrationCommand.php
@@ -44,7 +44,7 @@ class MigrationCommand extends MenuCommand
      *
      * @const STORE_PROCEDURE
      */
-    private const string STORE_PROCEDURE = 'Stored-Procedure';
+    private const string STORED_PROCEDURE = 'Stored-Procedure';
 
     /**
      * [List of available types]
@@ -54,7 +54,7 @@ class MigrationCommand extends MenuCommand
     private const array MIGRATIONS_OPTIONS = [
         self::TABLE,
         self::VIEW,
-        self::STORE_PROCEDURE,
+        self::STORED_PROCEDURE,
     ];
 
     /**
@@ -256,18 +256,18 @@ class MigrationCommand extends MenuCommand
             }
         }
 
-        if (self::STORE_PROCEDURE === $selectedType) {
-            $path = "database/Migrations/{$dbPascal}/{$driver}/StoreProcedures/";
+        if (self::STORED_PROCEDURE === $selectedType) {
+            $path = "database/Migrations/{$dbPascal}/{$driver}/StoredProcedures/";
 
             if ($this->databaseEngine->getDriver(Driver::MYSQL) === $driver) {
-                $body = $this->migrationFactory->getMySQLStoreProcedureBody(
+                $body = $this->migrationFactory->getMySQLStoredProcedureBody(
                     $className,
-                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\StoreProcedures"
+                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\StoredProcedures"
                 );
             } elseif ($this->databaseEngine->getDriver(Driver::POSTGRESQL) === $driver) {
-                $body = $this->migrationFactory->getPostgreSQLStoreProcedureBody(
+                $body = $this->migrationFactory->getPostgreSQLStoredProcedureBody(
                     $className,
-                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\StoreProcedures"
+                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\StoredProcedures"
                 );
             }
         }

--- a/src/LionBundle/Commands/Lion/New/MigrationCommand.php
+++ b/src/LionBundle/Commands/Lion/New/MigrationCommand.php
@@ -11,9 +11,7 @@ use Lion\Bundle\Helpers\Commands\Migrations\MigrationFactory;
 use Lion\Bundle\Helpers\Commands\Selection\MenuCommand;
 use Lion\Bundle\Helpers\DatabaseEngine;
 use Lion\Database\Connection;
-use Lion\Database\Driver;
 use LogicException;
-use stdClass;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -25,38 +23,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class MigrationCommand extends MenuCommand
 {
-    /**
-     * [Constant for a table]
-     *
-     * @const TABLE
-     */
-    private const string TABLE = 'Table';
-
-    /**
-     * [Constant for a view]
-     *
-     * @const VIEW
-     */
-    private const string VIEW = 'View';
-
-    /**
-     * [Constant for a store-procedure]
-     *
-     * @const STORE_PROCEDURE
-     */
-    private const string STORED_PROCEDURE = 'Stored-Procedure';
-
-    /**
-     * [List of available types]
-     *
-     * @const OPTIONS
-     */
-    private const array MIGRATIONS_OPTIONS = [
-        self::TABLE,
-        self::VIEW,
-        self::STORED_PROCEDURE,
-    ];
-
     /**
      * [Fabricates the data provided to manipulate information (folder, class,
      * namespace)]
@@ -154,7 +120,7 @@ class MigrationCommand extends MenuCommand
 
         $driver = $this->databaseEngine->getDriver($databaseEngineType);
 
-        $selectedType = $this->selectMigrationType($input, $output, self::MIGRATIONS_OPTIONS);
+        $selectedType = $this->selectMigrationType($input, $output, MigrationFactory::MIGRATIONS_OPTIONS);
 
         /** @var string $migrationPascal */
         $migrationPascal = $this->str
@@ -174,7 +140,7 @@ class MigrationCommand extends MenuCommand
             ->trim()
             ->get();
 
-        $dataMigration = $this->getBody($migrationPascal, $selectedType, $dbPascal, $driver);
+        $dataMigration = $this->migrationFactory->getBody($migrationPascal, $selectedType, $dbPascal, $driver);
 
         /** @var string $path */
         $path = $dataMigration->path;
@@ -206,75 +172,5 @@ class MigrationCommand extends MenuCommand
         );
 
         return parent::SUCCESS;
-    }
-
-    /**
-     * Gets the data to generate the body of the selected migration type
-     *
-     * @param string $className [Class name]
-     * @param string $selectedType [Type of migration]
-     * @param string $dbPascal [Database in PascalCase format]
-     * @param string $driver [Database Engine Type]
-     *
-     * @return stdClass
-     */
-    private function getBody(string $className, string $selectedType, string $dbPascal, string $driver): stdClass
-    {
-        $body = '';
-
-        $path = '';
-
-        if (self::TABLE === $selectedType) {
-            $path = "database/Migrations/{$dbPascal}/{$driver}/Tables/";
-
-            if ($this->databaseEngine->getDriver(Driver::MYSQL) === $driver) {
-                $body = $this->migrationFactory->getMySQLTableBody(
-                    $className,
-                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\Tables"
-                );
-            } elseif ($this->databaseEngine->getDriver(Driver::POSTGRESQL) === $driver) {
-                $body = $this->migrationFactory->getPostgreSQLTableBody(
-                    $className,
-                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\Tables"
-                );
-            }
-        }
-
-        if (self::VIEW === $selectedType) {
-            $path = "database/Migrations/{$dbPascal}/{$driver}/Views/";
-
-            if ($this->databaseEngine->getDriver(Driver::MYSQL) === $driver) {
-                $body = $this->migrationFactory->getMySQLViewBody(
-                    $className,
-                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\Views"
-                );
-            } elseif ($this->databaseEngine->getDriver(Driver::POSTGRESQL) === $driver) {
-                $body = $this->migrationFactory->getPostgreSQLViewBody(
-                    $className,
-                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\Views"
-                );
-            }
-        }
-
-        if (self::STORED_PROCEDURE === $selectedType) {
-            $path = "database/Migrations/{$dbPascal}/{$driver}/StoredProcedures/";
-
-            if ($this->databaseEngine->getDriver(Driver::MYSQL) === $driver) {
-                $body = $this->migrationFactory->getMySQLStoredProcedureBody(
-                    $className,
-                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\StoredProcedures"
-                );
-            } elseif ($this->databaseEngine->getDriver(Driver::POSTGRESQL) === $driver) {
-                $body = $this->migrationFactory->getPostgreSQLStoredProcedureBody(
-                    $className,
-                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\StoredProcedures"
-                );
-            }
-        }
-
-        return (object) [
-            'body' => $body,
-            'path' => $path,
-        ];
     }
 }

--- a/src/LionBundle/Helpers/Commands/Migrations/MigrationFactory.php
+++ b/src/LionBundle/Helpers/Commands/Migrations/MigrationFactory.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Lion\Bundle\Helpers\Commands\Migrations;
 
+use DI\Attribute\Inject;
+use Lion\Bundle\Helpers\DatabaseEngine;
+use Lion\Database\Driver;
+use stdClass;
+
 /**
  * Factory of the content of the generated migrations
  *
@@ -11,6 +16,123 @@ namespace Lion\Bundle\Helpers\Commands\Migrations;
  */
 class MigrationFactory
 {
+    /**
+     * [Constant for a table]
+     *
+     * @const TABLE
+     */
+    public const string TABLE = 'Table';
+
+    /**
+     * [Constant for a view]
+     *
+     * @const VIEW
+     */
+    public const string VIEW = 'View';
+
+    /**
+     * [Constant for a store-procedure]
+     *
+     * @const STORE_PROCEDURE
+     */
+    public const string STORED_PROCEDURE = 'Stored-Procedure';
+
+    /**
+     * [List of available types]
+     *
+     * @const OPTIONS
+     */
+    public const array MIGRATIONS_OPTIONS = [
+        self::TABLE,
+        self::VIEW,
+        self::STORED_PROCEDURE,
+    ];
+
+    /**
+     * [Manages basic database engine processes]
+     *
+     * @var DatabaseEngine $databaseEngine
+     */
+    private DatabaseEngine $databaseEngine;
+
+    #[Inject]
+    public function setDatabaseEngine(DatabaseEngine $databaseEngine): MigrationFactory
+    {
+        $this->databaseEngine = $databaseEngine;
+
+        return $this;
+    }
+
+    /**
+     * Gets the data to generate the body of the selected migration type
+     *
+     * @param string $className [Class name]
+     * @param string $selectedType [Type of migration]
+     * @param string $dbPascal [Database in PascalCase format]
+     * @param string $driver [Database Engine Type]
+     *
+     * @return stdClass
+     */
+    public function getBody(string $className, string $selectedType, string $dbPascal, string $driver): stdClass
+    {
+        $body = '';
+
+        $path = '';
+
+        if (self::TABLE === $selectedType) {
+            $path = "database/Migrations/{$dbPascal}/{$driver}/Tables/";
+
+            if ($this->databaseEngine->getDriver(Driver::MYSQL) === $driver) {
+                $body = $this->getMySQLTableBody(
+                    $className,
+                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\Tables"
+                );
+            } elseif ($this->databaseEngine->getDriver(Driver::POSTGRESQL) === $driver) {
+                $body = $this->getPostgreSQLTableBody(
+                    $className,
+                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\Tables"
+                );
+            }
+        }
+
+        if (self::VIEW === $selectedType) {
+            $path = "database/Migrations/{$dbPascal}/{$driver}/Views/";
+
+            if ($this->databaseEngine->getDriver(Driver::MYSQL) === $driver) {
+                $body = $this->getMySQLViewBody(
+                    $className,
+                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\Views"
+                );
+            } elseif ($this->databaseEngine->getDriver(Driver::POSTGRESQL) === $driver) {
+                $body = $this->getPostgreSQLViewBody(
+                    $className,
+                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\Views"
+                );
+            }
+        }
+
+        if (self::STORED_PROCEDURE === $selectedType) {
+            $path = "database/Migrations/{$dbPascal}/{$driver}/StoredProcedures/";
+
+            if ($this->databaseEngine->getDriver(Driver::MYSQL) === $driver) {
+                $body = $this->getMySQLStoredProcedureBody(
+                    $className,
+                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\StoredProcedures"
+                );
+            } elseif ($this->databaseEngine->getDriver(Driver::POSTGRESQL) === $driver) {
+                $body = $this->getPostgreSQLStoredProcedureBody(
+                    $className,
+                    "Database\\Migrations\\{$dbPascal}\\{$driver}\\StoredProcedures"
+                );
+            }
+        }
+
+        return (object) [
+            'body' => str_replace(['\r\n', '\r'], '\n', $body),
+            'path' => $path,
+        ];
+    }
+
     /**
      * Returns the body of the migration of type table
      *

--- a/src/LionBundle/Helpers/Commands/Migrations/MigrationFactory.php
+++ b/src/LionBundle/Helpers/Commands/Migrations/MigrationFactory.php
@@ -216,7 +216,7 @@ class MigrationFactory
      *
      * @return string
      */
-    public function getMySQLStoreProcedureBody(string $className, string $namespace): string
+    public function getMySQLStoredProcedureBody(string $className, string $namespace): string
     {
         return <<<PHP
         <?php
@@ -225,7 +225,7 @@ class MigrationFactory
 
         namespace {$namespace};
 
-        use Lion\Bundle\Interface\Migrations\StoreProcedureInterface;
+        use Lion\Bundle\Interface\Migrations\StoredProcedureInterface;
         use Lion\Database\Drivers\MySQL;
         use Lion\Database\Drivers\Schema\MySQL as Schema;
         use stdClass;
@@ -235,7 +235,7 @@ class MigrationFactory
          *
          * @package {$namespace}
          */
-        class {$className} implements StoreProcedureInterface
+        class {$className} implements StoredProcedureInterface
         {
             /**
              * {@inheritdoc}
@@ -265,7 +265,7 @@ class MigrationFactory
      *
      * @return string
      */
-    public function getPostgreSQLStoreProcedureBody(string $className, string $namespace): string
+    public function getPostgreSQLStoredProcedureBody(string $className, string $namespace): string
     {
         return <<<PHP
         <?php
@@ -274,7 +274,7 @@ class MigrationFactory
 
         namespace {$namespace};
 
-        use Lion\Bundle\Interface\Migrations\StoreProcedureInterface;
+        use Lion\Bundle\Interface\Migrations\StoredProcedureInterface;
         use Lion\Database\Drivers\PostgreSQL;
         use stdClass;
 
@@ -283,7 +283,7 @@ class MigrationFactory
          *
          * @package {$namespace}
          */
-        class {$className} implements StoreProcedureInterface
+        class {$className} implements StoredProcedureInterface
         {
             /**
              * {@inheritdoc}

--- a/src/LionBundle/Helpers/Commands/Migrations/Migrations.php
+++ b/src/LionBundle/Helpers/Commands/Migrations/Migrations.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Lion\Bundle\Helpers\Commands\Migrations;
 
 use DI\Attribute\Inject;
-use Lion\Bundle\Interface\Migrations\StoreProcedureInterface;
+use Lion\Bundle\Interface\Migrations\StoredProcedureInterface;
 use Lion\Bundle\Interface\Migrations\TableInterface;
 use Lion\Bundle\Interface\Migrations\ViewInterface;
 use Lion\Bundle\Interface\MigrationUpInterface;
@@ -89,7 +89,7 @@ class Migrations
         $allMigrations = [
             TableInterface::class => [],
             ViewInterface::class => [],
-            StoreProcedureInterface::class => [],
+            StoredProcedureInterface::class => [],
         ];
 
         foreach ($this->store->getFiles('./database/Migrations/') as $migration) {
@@ -113,8 +113,8 @@ class Migrations
                     $allMigrations[ViewInterface::class][$namespace] = $tableMigration;
                 }
 
-                if ($tableMigration instanceof StoreProcedureInterface) {
-                    $allMigrations[StoreProcedureInterface::class][$namespace] = $tableMigration;
+                if ($tableMigration instanceof StoredProcedureInterface) {
+                    $allMigrations[StoredProcedureInterface::class][$namespace] = $tableMigration;
                 }
             }
         }
@@ -167,7 +167,7 @@ class Migrations
         $migrations = [
             TableInterface::class => [],
             ViewInterface::class => [],
-            StoreProcedureInterface::class => [],
+            StoredProcedureInterface::class => [],
         ];
 
         foreach ($list as $namespace) {
@@ -182,8 +182,8 @@ class Migrations
                 $migrations[ViewInterface::class][$namespace] = $classObject;
             }
 
-            if ($classObject instanceof StoreProcedureInterface) {
-                $migrations[StoreProcedureInterface::class][$namespace] = $classObject;
+            if ($classObject instanceof StoredProcedureInterface) {
+                $migrations[StoredProcedureInterface::class][$namespace] = $classObject;
             }
         }
 
@@ -204,6 +204,6 @@ class Migrations
 
         $run($migrations[ViewInterface::class]);
 
-        $run($migrations[StoreProcedureInterface::class]);
+        $run($migrations[StoredProcedureInterface::class]);
     }
 }

--- a/src/LionBundle/Interface/Migrations/StoredProcedureInterface.php
+++ b/src/LionBundle/Interface/Migrations/StoredProcedureInterface.php
@@ -9,6 +9,6 @@ use Lion\Bundle\Interface\MigrationUpInterface;
 /**
  * Defines a stored procedure type migration
  */
-interface StoreProcedureInterface extends MigrationUpInterface
+interface StoredProcedureInterface extends MigrationUpInterface
 {
 }

--- a/tests/Commands/Lion/DB/ShowDatabasesCommandTest.php
+++ b/tests/Commands/Lion/DB/ShowDatabasesCommandTest.php
@@ -4,14 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Commands\Lion\DB;
 
-use DI\DependencyException;
-use DI\NotFoundException;
 use Lion\Bundle\Commands\Lion\DB\ShowDatabasesCommand;
-use Lion\Dependency\Injection\Container;
-use Lion\Helpers\Arr;
 use Lion\Test\Test;
 use PHPUnit\Framework\Attributes\Test as Testing;
-use ReflectionException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -24,37 +19,14 @@ class ShowDatabasesCommandTest extends Test
     private const string DATABASE_USER = 'root';
 
     private CommandTester $commandTester;
-    private ShowDatabasesCommand $showDatabasesCommand;
 
-    /**
-     * @throws ReflectionException
-     * @throws DependencyException
-     * @throws NotFoundException
-     */
     protected function setUp(): void
     {
-        /** @var ShowDatabasesCommand $showDatabasesCommand */
-        $showDatabasesCommand = new Container()->resolve(ShowDatabasesCommand::class);
-
-        $this->showDatabasesCommand = $showDatabasesCommand;
-
         $application = new Application();
 
-        $application->add($this->showDatabasesCommand);
+        $application->add(new ShowDatabasesCommand());
 
         $this->commandTester = new CommandTester($application->find('db:show'));
-
-        $this->initReflection($this->showDatabasesCommand);
-    }
-
-    /**
-     * @throws ReflectionException
-     */
-    #[Testing]
-    public function setArr(): void
-    {
-        $this->assertInstanceOf(ShowDatabasesCommand::class, $this->showDatabasesCommand->setArr(new Arr()));
-        $this->assertInstanceOf(Arr::class, $this->getPrivateProperty('arr'));
     }
 
     #[Testing]

--- a/tests/Commands/Lion/Migrations/EmptyMigrationsCommandTest.php
+++ b/tests/Commands/Lion/Migrations/EmptyMigrationsCommandTest.php
@@ -5,25 +5,50 @@ declare(strict_types=1);
 namespace Tests\Commands\Lion\Migrations;
 
 use Lion\Bundle\Commands\Lion\Migrations\EmptyMigrationsCommand;
+use Lion\Bundle\Helpers\Commands\Migrations\Migrations;
 use Lion\Test\Test;
 use PHPUnit\Framework\Attributes\Test as Testing;
+use ReflectionException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class EmptyMigrationsCommandTest extends Test
 {
-    private const string OUTPUT_MESSAGE = 'all tables have been truncated';
+    private const string OUTPUT_MESSAGE = 'All tables have been truncated';
 
     private CommandTester $commandTester;
+    private EmptyMigrationsCommand $emptyMigrationsCommand;
 
+    /**
+     * @throws ReflectionException
+     */
     protected function setUp(): void
     {
+        $this->emptyMigrationsCommand = new EmptyMigrationsCommand()
+            ->setMigrations(new Migrations());
+
         $application = new Application();
 
-        $application->add(new EmptyMigrationsCommand());
+        $application->add($this->emptyMigrationsCommand);
 
         $this->commandTester = new CommandTester($application->find('migrate:empty'));
+
+        $this->initReflection($this->emptyMigrationsCommand);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    #[Testing]
+    public function setMigrations(): void
+    {
+        $this->assertInstanceOf(
+            EmptyMigrationsCommand::class,
+            $this->emptyMigrationsCommand->setMigrations(new Migrations())
+        );
+
+        $this->assertInstanceOf(Migrations::class, $this->getPrivateProperty('migrations'));
     }
 
     #[Testing]

--- a/tests/Commands/Lion/Migrations/FreshMigrationsCommandTest.php
+++ b/tests/Commands/Lion/Migrations/FreshMigrationsCommandTest.php
@@ -12,6 +12,7 @@ use Lion\Bundle\Commands\Lion\New\MigrationCommand;
 use Lion\Bundle\Commands\Lion\New\SeedCommand;
 use Lion\Bundle\Helpers\Commands\Migrations\Migrations;
 use Lion\Command\Kernel;
+use Lion\Database\Drivers\Schema\MySQL;
 use Lion\Dependency\Injection\Container;
 use Lion\Test\Test;
 use PHPUnit\Framework\Attributes\Test as Testing;
@@ -111,6 +112,13 @@ class FreshMigrationsCommandTest extends Test
         $this->assertStringContainsString(self::OUTPUT_MESSAGE, $this->commandTesterFresh->getDisplay());
 
         $this->rmdirRecursively('./database/');
+
+        /** @var string $connectionName */
+        $connectionName = env('DB_DEFAULT');
+
+        MySQL::connection($connectionName)
+            ->dropTable('test')
+            ->execute();
     }
 
     #[Testing]

--- a/tests/Commands/Lion/New/MigrationCommandTest.php
+++ b/tests/Commands/Lion/New/MigrationCommandTest.php
@@ -10,7 +10,7 @@ use Lion\Bundle\Commands\Lion\New\MigrationCommand;
 use Lion\Bundle\Helpers\Commands\ClassFactory;
 use Lion\Bundle\Helpers\Commands\Migrations\MigrationFactory;
 use Lion\Bundle\Helpers\DatabaseEngine;
-use Lion\Bundle\Interface\Migrations\StoreProcedureInterface;
+use Lion\Bundle\Interface\Migrations\StoredProcedureInterface;
 use Lion\Bundle\Interface\Migrations\TableInterface;
 use Lion\Bundle\Interface\Migrations\ViewInterface;
 use Lion\Bundle\Interface\MigrationUpInterface;
@@ -29,18 +29,18 @@ class MigrationCommandTest extends Test
     private const string NAMESPACE_MYSQL_TABLE = 'Database\\Migrations\\LionDatabase\\MySQL\\Tables\\';
     private const string NAMESPACE_MYSQL_VIEW = 'Database\\Migrations\\LionDatabase\\MySQL\\Views\\';
     private const string NAMESPACE_MYSQL_STORE_PROCEDURES =
-        'Database\\Migrations\\LionDatabase\\MySQL\\StoreProcedures\\';
+        'Database\\Migrations\\LionDatabase\\MySQL\\StoredProcedures\\';
     private const string NAMESPACE_POSTGRESQL_TABLE = 'Database\\Migrations\\LionDatabase\\PostgreSQL\\Tables\\';
     private const string NAMESPACE_POSTGRESQL_VIEW = 'Database\\Migrations\\LionDatabase\\PostgreSQL\\Views\\';
     private const string NAMESPACE_POSTGRESQL_STORE_PROCEDURES =
-        'Database\\Migrations\\LionDatabase\\PostgreSQL\\StoreProcedures\\';
+        'Database\\Migrations\\LionDatabase\\PostgreSQL\\StoredProcedures\\';
     private const string URL_PATH_MYSQL_TABLE = './database/Migrations/LionDatabase/MySQL/Tables/';
     private const string URL_PATH_MYSQL_VIEW = './database/Migrations/LionDatabase/MySQL/Views/';
-    private const string URL_PATH_MYSQL_STORE_PROCEDURES = './database/Migrations/LionDatabase/MySQL/StoreProcedures/';
+    private const string URL_PATH_MYSQL_STORE_PROCEDURES = './database/Migrations/LionDatabase/MySQL/StoredProcedures/';
     private const string URL_PATH_POSTGRESQL_TABLE = './database/Migrations/LionDatabase/PostgreSQL/Tables/';
     private const string URL_PATH_POSTGRESQL_VIEW = './database/Migrations/LionDatabase/PostgreSQL/Views/';
     private const string URL_PATH_POSTGRESQL_STORE_PROCEDURES =
-        './database/Migrations/LionDatabase/PostgreSQL/StoreProcedures/';
+        './database/Migrations/LionDatabase/PostgreSQL/StoredProcedures/';
     private const string FILE_NAME = self::CLASS_NAME . '.php';
     private const string OUTPUT_MESSAGE = 'migration has been generated';
 
@@ -193,7 +193,7 @@ class MigrationCommandTest extends Test
         /** @phpstan-ignore-next-line */
         $this->assertInstances($objClass, [
             MigrationUpInterface::class,
-            StoreProcedureInterface::class,
+            StoredProcedureInterface::class,
         ]);
     }
 
@@ -271,7 +271,7 @@ class MigrationCommandTest extends Test
         /** @phpstan-ignore-next-line */
         $this->assertInstances($objClass, [
             MigrationUpInterface::class,
-            StoreProcedureInterface::class,
+            StoredProcedureInterface::class,
         ]);
     }
 }

--- a/tests/Commands/Lion/New/MigrationCommandTest.php
+++ b/tests/Commands/Lion/New/MigrationCommandTest.php
@@ -138,7 +138,6 @@ class MigrationCommandTest extends Test
         /** @phpstan-ignore-next-line */
         $objClass = new (self::NAMESPACE_MYSQL_TABLE . self::CLASS_NAME)();
 
-        /** @phpstan-ignore-next-line */
         $this->assertInstances($objClass, [
             MigrationUpInterface::class,
             TableInterface::class,
@@ -164,7 +163,6 @@ class MigrationCommandTest extends Test
         /** @phpstan-ignore-next-line */
         $objClass = new (self::NAMESPACE_MYSQL_VIEW . self::CLASS_NAME)();
 
-        /** @phpstan-ignore-next-line */
         $this->assertInstances($objClass, [
             MigrationUpInterface::class,
             ViewInterface::class,
@@ -190,7 +188,6 @@ class MigrationCommandTest extends Test
         /** @phpstan-ignore-next-line */
         $objClass = new (self::NAMESPACE_MYSQL_STORE_PROCEDURES . self::CLASS_NAME)();
 
-        /** @phpstan-ignore-next-line */
         $this->assertInstances($objClass, [
             MigrationUpInterface::class,
             StoredProcedureInterface::class,
@@ -216,7 +213,6 @@ class MigrationCommandTest extends Test
         /** @phpstan-ignore-next-line */
         $objClass = new (self::NAMESPACE_POSTGRESQL_TABLE . self::CLASS_NAME)();
 
-        /** @phpstan-ignore-next-line */
         $this->assertInstances($objClass, [
             MigrationUpInterface::class,
             TableInterface::class,
@@ -242,7 +238,6 @@ class MigrationCommandTest extends Test
         /** @phpstan-ignore-next-line */
         $objClass = new (self::NAMESPACE_POSTGRESQL_VIEW . self::CLASS_NAME)();
 
-        /** @phpstan-ignore-next-line */
         $this->assertInstances($objClass, [
             MigrationUpInterface::class,
             ViewInterface::class,
@@ -268,7 +263,6 @@ class MigrationCommandTest extends Test
         /** @phpstan-ignore-next-line */
         $objClass = new (self::NAMESPACE_POSTGRESQL_STORE_PROCEDURES . self::CLASS_NAME)();
 
-        /** @phpstan-ignore-next-line */
         $this->assertInstances($objClass, [
             MigrationUpInterface::class,
             StoredProcedureInterface::class,

--- a/tests/Helpers/Commands/Migrations/MigrationFactoryTest.php
+++ b/tests/Helpers/Commands/Migrations/MigrationFactoryTest.php
@@ -65,7 +65,7 @@ class MigrationFactoryTest extends Test
     #[DataProvider('getMySQLStoreProcedureBodyProvider')]
     public function getMySQLStoreProcedureBody(string $className, string $namespace, string $body): void
     {
-        $return = $this->migrationFactory->getMySQLStoreProcedureBody($className, $namespace);
+        $return = $this->migrationFactory->getMySQLStoredProcedureBody($className, $namespace);
 
         $this->assertIsString($return);
         $this->assertSame($body, $return);
@@ -75,7 +75,7 @@ class MigrationFactoryTest extends Test
     #[DataProvider('getPostgreSQLStoreProcedureBodyProvider')]
     public function getPostgreSQLStoreProcedureBody(string $className, string $namespace, string $body): void
     {
-        $return = $this->migrationFactory->getPostgreSQLStoreProcedureBody($className, $namespace);
+        $return = $this->migrationFactory->getPostgreSQLStoredProcedureBody($className, $namespace);
 
         $this->assertIsString($return);
         $this->assertSame($body, $return);

--- a/tests/Helpers/Commands/Migrations/MigrationsTest.php
+++ b/tests/Helpers/Commands/Migrations/MigrationsTest.php
@@ -8,7 +8,7 @@ use DI\DependencyException;
 use DI\NotFoundException;
 use Lion\Bundle\Commands\Lion\New\MigrationCommand;
 use Lion\Bundle\Helpers\Commands\Migrations\Migrations;
-use Lion\Bundle\Interface\Migrations\StoreProcedureInterface;
+use Lion\Bundle\Interface\Migrations\StoredProcedureInterface;
 use Lion\Bundle\Interface\Migrations\TableInterface;
 use Lion\Bundle\Interface\Migrations\ViewInterface;
 use Lion\Bundle\Interface\MigrationUpInterface;
@@ -28,10 +28,10 @@ class MigrationsTest extends Test
     private const string CLASS_NAMESPACE_TABLE = 'Database\\Migrations\\LionDatabase\\MySQL\\Tables\\';
     private const string CLASS_NAMESPACE_VIEW = 'Database\\Migrations\\LionDatabase\\MySQL\\Views\\';
     private const string CLASS_NAMESPACE_STORE_PROCEDURE =
-        'Database\\Migrations\\LionDatabase\\MySQL\\StoreProcedures\\';
+        'Database\\Migrations\\LionDatabase\\MySQL\\StoredProcedures\\';
     private const string URL_PATH_MYSQL_TABLE = './database/Migrations/LionDatabase/MySQL/Tables/';
     private const string URL_PATH_MYSQL_VIEW = './database/Migrations/LionDatabase/MySQL/Views/';
-    private const string URL_PATH_MYSQL_STORE_PROCEDURE = './database/Migrations/LionDatabase/MySQL/StoreProcedures/';
+    private const string URL_PATH_MYSQL_STORED_PROCEDURE = './database/Migrations/LionDatabase/MySQL/StoredProcedures/';
     private const string FILE_NAME = self::CLASS_NAME . '.php';
     private const string OUTPUT_MESSAGE = 'migration has been generated';
 
@@ -101,7 +101,6 @@ class MigrationsTest extends Test
         /** @phpstan-ignore-next-line */
         $tableMigration = new (self::CLASS_NAMESPACE_TABLE . self::CLASS_NAME)();
 
-        /** @phpstan-ignore-next-line */
         $this->assertInstances($tableMigration, [
             MigrationUpInterface::class,
             TableInterface::class,
@@ -145,7 +144,6 @@ class MigrationsTest extends Test
         /** @phpstan-ignore-next-line */
         $tableMigration = new (self::CLASS_NAMESPACE_TABLE . self::CLASS_NAME)();
 
-        /** @phpstan-ignore-next-line */
         $this->assertInstances($tableMigration, [
             MigrationUpInterface::class,
             TableInterface::class,
@@ -167,7 +165,6 @@ class MigrationsTest extends Test
         /** @phpstan-ignore-next-line */
         $viewMigration = new (self::CLASS_NAMESPACE_VIEW . self::CLASS_NAME)();
 
-        /** @phpstan-ignore-next-line */
         $this->assertInstances($viewMigration, [
             MigrationUpInterface::class,
             ViewInterface::class,
@@ -184,15 +181,14 @@ class MigrationsTest extends Test
 
         $this->assertSame(Command::SUCCESS, $commandExecute);
         $this->assertStringContainsString(self::OUTPUT_MESSAGE, $this->commandTester->getDisplay());
-        $this->assertFileExists(self::URL_PATH_MYSQL_STORE_PROCEDURE . self::FILE_NAME);
+        $this->assertFileExists(self::URL_PATH_MYSQL_STORED_PROCEDURE . self::FILE_NAME);
 
         /** @phpstan-ignore-next-line */
         $viewMigration = new (self::CLASS_NAMESPACE_STORE_PROCEDURE . self::CLASS_NAME)();
 
-        /** @phpstan-ignore-next-line */
         $this->assertInstances($viewMigration, [
             MigrationUpInterface::class,
-            StoreProcedureInterface::class,
+            StoredProcedureInterface::class,
         ]);
 
         $list = $this->migrations->getMigrations();
@@ -200,10 +196,10 @@ class MigrationsTest extends Test
         $this->assertNotEmpty($list);
         $this->assertArrayHasKey(TableInterface::class, $list);
         $this->assertArrayHasKey(ViewInterface::class, $list);
-        $this->assertArrayHasKey(StoreProcedureInterface::class, $list);
+        $this->assertArrayHasKey(StoredProcedureInterface::class, $list);
         $this->assertNotEmpty($list[TableInterface::class]);
         $this->assertNotEmpty($list[ViewInterface::class]);
-        $this->assertNotEmpty($list[StoreProcedureInterface::class]);
+        $this->assertNotEmpty($list[StoredProcedureInterface::class]);
 
         $this->assertInstanceOf(
             TableInterface::class,
@@ -216,8 +212,8 @@ class MigrationsTest extends Test
         );
 
         $this->assertInstanceOf(
-            StoreProcedureInterface::class,
-            $list[StoreProcedureInterface::class][self::CLASS_NAMESPACE_STORE_PROCEDURE . self::CLASS_NAME]
+            StoredProcedureInterface::class,
+            $list[StoredProcedureInterface::class][self::CLASS_NAMESPACE_STORE_PROCEDURE . self::CLASS_NAME]
         );
     }
 
@@ -232,6 +228,7 @@ class MigrationsTest extends Test
         $this->assertStringContainsString(self::OUTPUT_MESSAGE, $this->commandTester->getDisplay());
         $this->assertFileExists(self::URL_PATH_MYSQL_TABLE . self::FILE_NAME);
 
+        /** @phpstan-ignore-next-line */
         $objClass = new (self::CLASS_NAMESPACE_TABLE . self::CLASS_NAME)();
 
         $this->assertInstances($objClass, [
@@ -247,6 +244,7 @@ class MigrationsTest extends Test
         $this->assertStringContainsString(self::OUTPUT_MESSAGE, $this->commandTester->getDisplay());
         $this->assertFileExists(self::URL_PATH_MYSQL_VIEW . self::FILE_NAME);
 
+        /** @phpstan-ignore-next-line */
         $objClass = new (self::CLASS_NAMESPACE_VIEW . self::CLASS_NAME)();
 
         $this->assertInstances($objClass, [
@@ -260,15 +258,17 @@ class MigrationsTest extends Test
 
         $this->assertSame(Command::SUCCESS, $commandExecute);
         $this->assertStringContainsString(self::OUTPUT_MESSAGE, $this->commandTester->getDisplay());
-        $this->assertFileExists(self::URL_PATH_MYSQL_STORE_PROCEDURE . self::FILE_NAME);
+        $this->assertFileExists(self::URL_PATH_MYSQL_STORED_PROCEDURE . self::FILE_NAME);
 
+        /** @phpstan-ignore-next-line */
         $objClass = new (self::CLASS_NAMESPACE_STORE_PROCEDURE . self::CLASS_NAME)();
 
         $this->assertInstances($objClass, [
             MigrationUpInterface::class,
-            StoreProcedureInterface::class,
+            StoredProcedureInterface::class,
         ]);
 
+        /** @phpstan-ignore-next-line */
         $this->migrations->executeMigrationsGroup([
             self::CLASS_NAMESPACE_TABLE . self::CLASS_NAME,
             self::CLASS_NAMESPACE_VIEW . self::CLASS_NAME,

--- a/tests/Providers/Helpers/Commands/MigrationsFactoryProviderTrait.php
+++ b/tests/Providers/Helpers/Commands/MigrationsFactoryProviderTrait.php
@@ -208,7 +208,7 @@ trait MigrationsFactoryProviderTrait
 
                 namespace Database\Migrations\LionDatabase\MySQL\StoreProcedures;
 
-                use Lion\Bundle\Interface\Migrations\StoreProcedureInterface;
+                use Lion\Bundle\Interface\Migrations\StoredProcedureInterface;
                 use Lion\Database\Drivers\MySQL;
                 use Lion\Database\Drivers\Schema\MySQL as Schema;
                 use stdClass;
@@ -218,7 +218,7 @@ trait MigrationsFactoryProviderTrait
                  *
                  * @package Database\Migrations\LionDatabase\MySQL\StoreProcedures
                  */
-                class Test implements StoreProcedureInterface
+                class Test implements StoredProcedureInterface
                 {
                     /**
                      * {@inheritdoc}
@@ -255,7 +255,7 @@ trait MigrationsFactoryProviderTrait
 
                 namespace Database\Migrations\LionDatabase\PostgreSQL\StoreProcedures;
 
-                use Lion\Bundle\Interface\Migrations\StoreProcedureInterface;
+                use Lion\Bundle\Interface\Migrations\StoredProcedureInterface;
                 use Lion\Database\Drivers\PostgreSQL;
                 use stdClass;
 
@@ -264,7 +264,7 @@ trait MigrationsFactoryProviderTrait
                  *
                  * @package Database\Migrations\LionDatabase\PostgreSQL\StoreProcedures
                  */
-                class Test implements StoreProcedureInterface
+                class Test implements StoredProcedureInterface
                 {
                     /**
                      * {@inheritdoc}

--- a/tests/Providers/Helpers/Commands/MigrationsFactoryProviderTrait.php
+++ b/tests/Providers/Helpers/Commands/MigrationsFactoryProviderTrait.php
@@ -4,8 +4,278 @@ declare(strict_types=1);
 
 namespace Tests\Providers\Helpers\Commands;
 
+use Lion\Bundle\Helpers\Commands\Migrations\MigrationFactory;
+
 trait MigrationsFactoryProviderTrait
 {
+    public static function getBodyProvider(): array
+    {
+        return [
+            [
+                'className' => 'Test',
+                'selectedType' => MigrationFactory::TABLE,
+                'dbPascal' => 'LionDatabase',
+                'driver' => 'MySQL',
+                'path' => 'database/Migrations/LionDatabase/MySQL/Tables/',
+                'return' => <<<PHP
+                <?php
+
+                declare(strict_types=1);
+
+                namespace Database\Migrations\LionDatabase\MySQL\Tables;
+
+                use Lion\Bundle\Interface\Migrations\TableInterface;
+                use Lion\Database\Drivers\Schema\MySQL as Schema;
+                use stdClass;
+
+                /**
+                 * Description
+                 *
+                 * @package Database\Migrations\LionDatabase\MySQL\Tables
+                 */
+                class Test implements TableInterface
+                {
+                    /**
+                     * [Index number for seed execution priority]
+                     *
+                     * @const INDEX
+                     */
+                    public const ?int INDEX = null;
+
+                    /**
+                     * {@inheritdoc}
+                     */
+                    public function up(): stdClass
+                    {
+                        return Schema::connection(env('DB_DEFAULT', 'local'))
+                            ->createTable('--NAME--', function (): void {
+                                Schema::int('id')->notNull()->autoIncrement()->primaryKey();
+                            })
+                            ->execute();
+                    }
+                }
+
+                PHP,
+            ],
+            [
+                'className' => 'Test',
+                'selectedType' => MigrationFactory::TABLE,
+                'dbPascal' => 'LionDatabase',
+                'driver' => 'PostgreSQL',
+                'path' => 'database/Migrations/LionDatabase/PostgreSQL/Tables/',
+                'return' => <<<PHP
+                <?php
+
+                declare(strict_types=1);
+
+                namespace Database\Migrations\LionDatabase\PostgreSQL\Tables;
+
+                use Lion\Bundle\Interface\Migrations\TableInterface;
+                use Lion\Database\Drivers\PostgreSQL;
+                use stdClass;
+
+                /**
+                 * Description
+                 *
+                 * @package Database\Migrations\LionDatabase\PostgreSQL\Tables
+                 */
+                class Test implements TableInterface
+                {
+                    /**
+                     * [Index number for seed execution priority]
+                     *
+                     * @const INDEX
+                     */
+                    public const ?int INDEX = null;
+
+                    /**
+                     * {@inheritdoc}
+                     */
+                    public function up(): stdClass
+                    {
+                        return PostgreSQL::connection(env('DB_DEFAULT', 'local'))
+                            ->query(
+                                <<<SQL
+                                -- SQL
+                                SQL
+                            )
+                            ->execute();
+                    }
+                }
+
+                PHP,
+            ],
+            [
+                'className' => 'Test',
+                'selectedType' => MigrationFactory::VIEW,
+                'dbPascal' => 'LionDatabase',
+                'driver' => 'MySQL',
+                'path' => 'database/Migrations/LionDatabase/MySQL/Views/',
+                'return' => <<<PHP
+                <?php
+
+                declare(strict_types=1);
+
+                namespace Database\Migrations\LionDatabase\MySQL\Views;
+
+                use Lion\Bundle\Interface\Migrations\ViewInterface;
+                use Lion\Database\Drivers\MySQL;
+                use Lion\Database\Drivers\Schema\MySQL as Schema;
+                use stdClass;
+
+                /**
+                 * Description
+                 *
+                 * @package Database\Migrations\LionDatabase\MySQL\Views
+                 */
+                class Test implements ViewInterface
+                {
+                    /**
+                     * {@inheritdoc}
+                     */
+                    public function up(): stdClass
+                    {
+                        return Schema::connection(env('DB_DEFAULT', 'local'))
+                            ->createView('--NAME--', function (MySQL \$db): void {
+                                \$db
+                                    ->table('table')
+                                    ->select();
+                            })
+                            ->execute();
+                    }
+                }
+
+                PHP,
+            ],
+            [
+                'className' => 'Test',
+                'selectedType' => MigrationFactory::VIEW,
+                'dbPascal' => 'LionDatabase',
+                'driver' => 'PostgreSQL',
+                'path' => 'database/Migrations/LionDatabase/PostgreSQL/Views/',
+                'return' => <<<PHP
+                <?php
+
+                declare(strict_types=1);
+
+                namespace Database\Migrations\LionDatabase\PostgreSQL\Views;
+
+                use Lion\Bundle\Interface\Migrations\ViewInterface;
+                use Lion\Database\Drivers\PostgreSQL;
+                use stdClass;
+
+                /**
+                 * Description
+                 *
+                 * @package Database\Migrations\LionDatabase\PostgreSQL\Views
+                 */
+                class Test implements ViewInterface
+                {
+                    /**
+                     * {@inheritdoc}
+                     */
+                    public function up(): stdClass
+                    {
+                        return PostgreSQL::connection(env('DB_DEFAULT', 'local'))
+                            ->query(
+                                <<<SQL
+                                -- SQL
+                                SQL
+                            )
+                            ->execute();
+                    }
+                }
+
+                PHP,
+            ],
+            [
+                'className' => 'Test',
+                'selectedType' => MigrationFactory::STORED_PROCEDURE,
+                'dbPascal' => 'LionDatabase',
+                'driver' => 'MySQL',
+                'path' => 'database/Migrations/LionDatabase/MySQL/StoredProcedures/',
+                'return' => <<<PHP
+                <?php
+
+                declare(strict_types=1);
+
+                namespace Database\Migrations\LionDatabase\MySQL\StoredProcedures;
+
+                use Lion\Bundle\Interface\Migrations\StoredProcedureInterface;
+                use Lion\Database\Drivers\MySQL;
+                use Lion\Database\Drivers\Schema\MySQL as Schema;
+                use stdClass;
+
+                /**
+                 * Description
+                 *
+                 * @package Database\Migrations\LionDatabase\MySQL\StoredProcedures
+                 */
+                class Test implements StoredProcedureInterface
+                {
+                    /**
+                     * {@inheritdoc}
+                     */
+                    public function up(): stdClass
+                    {
+                        return Schema::connection(env('DB_DEFAULT', 'local'))
+                            ->createStoreProcedure('--NAME--', function (): void {
+                                Schema::in()->varchar('name', 25);
+                            }, function (MySQL \$db): void {
+                                \$db
+                                    ->table('')
+                                    ->insert(['name' => '']);
+                            })
+                            ->execute();
+                    }
+                }
+
+                PHP,
+            ],
+            [
+                'className' => 'Test',
+                'selectedType' => MigrationFactory::STORED_PROCEDURE,
+                'dbPascal' => 'LionDatabase',
+                'driver' => 'PostgreSQL',
+                'path' => 'database/Migrations/LionDatabase/PostgreSQL/StoredProcedures/',
+                'return' => <<<PHP
+                <?php
+
+                declare(strict_types=1);
+
+                namespace Database\Migrations\LionDatabase\PostgreSQL\StoredProcedures;
+
+                use Lion\Bundle\Interface\Migrations\StoredProcedureInterface;
+                use Lion\Database\Drivers\PostgreSQL;
+                use stdClass;
+
+                /**
+                 * Description
+                 *
+                 * @package Database\Migrations\LionDatabase\PostgreSQL\StoredProcedures
+                 */
+                class Test implements StoredProcedureInterface
+                {
+                    /**
+                     * {@inheritdoc}
+                     */
+                    public function up(): stdClass
+                    {
+                        return PostgreSQL::connection(env('DB_DEFAULT', 'local'))
+                            ->query(
+                                <<<SQL
+                                -- SQL
+                                SQL
+                            )
+                            ->execute();
+                    }
+                }
+
+                PHP,
+            ],
+        ];
+    }
+
     public static function getMySQLTableBodyProvider(): array
     {
         return [
@@ -237,7 +507,7 @@ trait MigrationsFactoryProviderTrait
                     }
                 }
 
-                PHP
+                PHP,
             ],
         ];
     }
@@ -281,7 +551,7 @@ trait MigrationsFactoryProviderTrait
                     }
                 }
 
-                PHP
+                PHP,
             ],
         ];
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,32 +41,36 @@ if (isSuccess(new Store()->exist(__DIR__ . '/../.env'))) {
  * -----------------------------------------------------------------------------
  */
 
+$privateConnections = [
+    env('DB_DEFAULT') => [
+        'type' => env('DB_TYPE'),
+        'host' => env('DB_HOST'),
+        'port' => env('DB_PORT'),
+        'dbname' => env('DB_NAME'),
+        'user' => env('DB_USER'),
+        'password' => env('DB_PASSWORD'),
+    ],
+    env('DB_NAME_TEST') => [
+        'type' => env('DB_TYPE_TEST'),
+        'host' => env('DB_HOST_TEST'),
+        'port' => env('DB_PORT_TEST'),
+        'dbname' => env('DB_NAME'),
+        'user' => env('DB_USER_TEST'),
+        'password' => env('DB_PASSWORD_TEST'),
+    ],
+    env('DB_NAME_TEST_POSTGRESQL') => [
+        'type' => env('DB_TYPE_TEST_POSTGRESQL'),
+        'host' => env('DB_HOST_TEST_POSTGRESQL'),
+        'port' => env('DB_PORT_TEST_POSTGRESQL'),
+        'dbname' => env('DB_NAME'),
+        'user' => env('DB_USER_TEST_POSTGRESQL'),
+        'password' => env('DB_PASSWORD_TEST_POSTGRESQL'),
+    ],
+];
+
 Driver::run([
     'default' => env('DB_DEFAULT'),
-    'connections' => [
-        env('DB_DEFAULT') => [
-            'type' => env('DB_TYPE'),
-            'host' => env('DB_HOST'),
-            'port' => env('DB_PORT'),
-            'dbname' => env('DB_NAME'),
-            'user' => env('DB_USER'),
-            'password' => env('DB_PASSWORD'),
-        ],
-        env('DB_NAME_TEST') => [
-            'type' => env('DB_TYPE_TEST'),
-            'host' => env('DB_HOST_TEST'),
-            'port' => env('DB_PORT_TEST'),
-            'dbname' => env('DB_NAME'),
-            'user' => env('DB_USER_TEST'),
-            'password' => env('DB_PASSWORD_TEST'),
-        ],
-        env('DB_NAME_TEST_POSTGRESQL') => [
-            'type' => env('DB_TYPE_TEST_POSTGRESQL'),
-            'host' => env('DB_HOST_TEST_POSTGRESQL'),
-            'port' => env('DB_PORT_TEST_POSTGRESQL'),
-            'dbname' => env('DB_NAME'),
-            'user' => env('DB_USER_TEST_POSTGRESQL'),
-            'password' => env('DB_PASSWORD_TEST_POSTGRESQL'),
-        ],
-    ],
+    'connections' => $privateConnections,
 ]);
+
+define('NUMBER_OF_ACTIVE_CONNECTIONS', count($privateConnections));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -66,6 +66,10 @@ $privateConnections = [
         'user' => env('DB_USER_TEST_POSTGRESQL'),
         'password' => env('DB_PASSWORD_TEST_POSTGRESQL'),
     ],
+    'lion_database_sqlite' => [
+        'type' => env('DB_TYPE_TEST_SQLITE'),
+        'dbname' => __DIR__ . '/' . env('DB_NAME_TEST_SQLITE'),
+    ],
 ];
 
 Driver::run([


### PR DESCRIPTION
### Added
- Test is added for MigrationCommand.
- Test added for EmptyMigrationCommand.
- Added static connection support for high-level processes.

### Refactoring
- StoreProcedureInterface name changed to StoredProcedureInterface.
- Added approach to drop databases instead of dropping tables when updating migrations.